### PR TITLE
refactor: unified-message-control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 .nyc_output/
 coverage/
 node_modules/
-remark-message-control.js
-remark-message-control.min.js
+unified-message-control.js
+unified-message-control.min.js

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 var trim = require('trim');
 var location = require('vfile-location');
 var visit = require('unist-util-visit');
-var marker = require('mdast-comment-marker');
 
 /* Map of allowed verbs. */
 var ALLOWED_VERBS = {
@@ -16,6 +15,7 @@ module.exports = messageControl;
 
 function messageControl(options) {
   var name = options && options.name;
+  var marker = options && options.marker;
   var sources;
   var known;
   var reset;
@@ -23,6 +23,10 @@ function messageControl(options) {
   var disable;
 
   if (!name) {
+    throw new Error('Expected `name` in `options`, got `' + name + '`');
+  }
+
+  if (!marker) {
     throw new Error('Expected `name` in `options`, got `' + name + '`');
   }
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = messageControl;
 function messageControl(options) {
   var name = options && options.name;
   var marker = options && options.marker;
+  var test = options && options.test;
   var sources;
   var known;
   var reset;
@@ -28,6 +29,10 @@ function messageControl(options) {
 
   if (!marker) {
     throw new Error('Expected `name` in `options`, got `' + name + '`');
+  }
+
+  if (!test) {
+    throw new Error('Expected `test` in `options`, got `' + test + '`');
   }
 
   known = options.known;
@@ -51,7 +56,7 @@ function messageControl(options) {
     var scope = {};
     var globals = [];
 
-    visit(tree, 'html', visitor);
+    visit(tree, test, visitor);
 
     file.messages = file.messages.filter(filter);
 
@@ -78,8 +83,10 @@ function messageControl(options) {
 
       if (!verb || !ALLOWED_VERBS[verb] === true) {
         file.fail(
-          'Unknown keyword `' + verb + '`: expected ' +
-          '`\'enable\'`, `\'disable\'`, or `\'ignore\'`',
+          'Unknown keyword `' +
+            verb +
+            '`: expected ' +
+            '`\'enable\'`, `\'disable\'`, or `\'ignore\'`',
           mark.node
         );
       }
@@ -136,10 +143,7 @@ function messageControl(options) {
       pos = toOffset(message);
 
       while (gapIndex--) {
-        if (
-          gaps[gapIndex].start <= pos &&
-          gaps[gapIndex].end > pos
-        ) {
+        if (gaps[gapIndex].start <= pos && gaps[gapIndex].end > pos) {
           return false;
         }
       }
@@ -221,7 +225,8 @@ function messageControl(options) {
 
         if (
           range.position.line < message.line ||
-          (range.position.line === message.line && range.position.column < message.column)
+          (range.position.line === message.line &&
+            range.position.column < message.column)
         ) {
           return range.state === true;
         }
@@ -262,10 +267,7 @@ function detectGaps(tree, file) {
     update();
 
     update(
-      tree &&
-      tree.position &&
-      tree.position.end &&
-      tree.position.end.offset - 1
+      tree && tree.position && tree.position.end && tree.position.end.offset - 1
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "remark-message-control",
-  "version": "4.0.2",
-  "description": "Enable, disable, and ignore messages with remark",
+  "name": "unified-message-control",
+  "version": "0.0.0",
+  "description": "Enable, disable, and ignore messages from unified processors",
   "license": "MIT",
   "keywords": [
-    "remark",
+    "unified",
     "comment",
     "message",
     "marker",
@@ -20,7 +20,6 @@
     "index.js"
   ],
   "dependencies": {
-    "mdast-comment-marker": "^1.0.0",
     "trim": "0.0.1",
     "unist-util-visit": "^1.0.0",
     "vfile-location": "^2.0.0"
@@ -38,8 +37,8 @@
   },
   "scripts": {
     "build-md": "remark . -qfo",
-    "build-bundle": "browserify index.js --bare -s remarkMessageControl > remark-message-control.js",
-    "build-mangle": "esmangle remark-message-control.js > remark-message-control.min.js",
+    "build-bundle": "browserify index.js --bare -s unifiedMessageControl > unified-message-control.js",
+    "build-mangle": "esmangle unified-message-control.js > unified-message-control.min.js",
     "build": "npm run build-md && npm run build-bundle && npm run build-mangle",
     "lint": "xo",
     "test-api": "node test.js",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "browserify": "^14.0.0",
     "esmangle": "^1.0.0",
+    "mdast-comment-marker": "^1.0.2",
     "nyc": "^11.0.0",
     "remark": "^8.0.0",
     "remark-cli": "^4.0.0",

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# remark-message-control [![Build Status][build-badge]][build-status] [![Coverage Status][coverage-badge]][coverage-status] [![Chat][chat-badge]][chat]
+# unified-message-control [![Build Status][build-badge]][build-status] [![Coverage Status][coverage-badge]][coverage-status] [![Chat][chat-badge]][chat]
 
 Enable, disable, and ignore messages with [**remark**][remark].
 
@@ -163,17 +163,17 @@ repository, organisation, or community you agree to abide by its terms.
 
 <!-- Definitions -->
 
-[build-badge]: https://img.shields.io/travis/remarkjs/remark-message-control.svg
+[build-badge]: https://img.shields.io/travis/unifiedjs/unified-message-control.svg
 
-[build-status]: https://travis-ci.org/remarkjs/remark-message-control
+[build-status]: https://travis-ci.org/unifiedjs/unified-message-control
 
 [coverage-badge]: https://img.shields.io/codecov/c/github/remarkjs/remark-message-control.svg
 
 [coverage-status]: https://codecov.io/github/remarkjs/remark-message-control
 
-[chat-badge]: https://img.shields.io/gitter/room/remarkjs/Lobby.svg
+[chat-badge]: https://img.shields.io/gitter/room/unifiedjs/Lobby.svg
 
-[chat]: https://gitter.im/remarkjs/Lobby
+[chat]: https://gitter.im/unifiedjs/Lobby
 
 [license]: LICENSE
 

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@
 var test = require('tape');
 var remark = require('remark');
 var toc = require('remark-toc');
+var mdastMarker = require('mdast-comment-marker');
 var control = require('./');
 
 test('control()', function (t) {
@@ -11,7 +12,7 @@ test('control()', function (t) {
   }, /Expected `name` in `options`, got `undefined`/);
 
   remark().use(function () {
-    var transformer = control({name: 'foo'});
+    var transformer = control({name: 'foo', marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', tree.children[1], 'foo:bar');
@@ -32,7 +33,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    var transformer = control({name: 'foo'});
+    var transformer = control({name: 'foo', marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', tree.children[1], 'foo:bar');
@@ -54,7 +55,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    var transformer = control({name: 'foo', reset: true});
+    var transformer = control({name: 'foo', reset: true, marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', tree.children[0], 'foo:bar');
@@ -79,7 +80,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    var transformer = control({name: 'foo', reset: true});
+    var transformer = control({name: 'foo', reset: true, marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', tree.children[1], 'foo:bar');
@@ -101,7 +102,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    var transformer = control({name: 'foo'});
+    var transformer = control({name: 'foo', marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', tree.children[1], 'foo:bar');
@@ -128,7 +129,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    var transformer = control({name: 'foo'});
+    var transformer = control({name: 'foo', marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', tree.children[1], 'foo:bar');
@@ -155,7 +156,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    var transformer = control({name: 'foo'});
+    var transformer = control({name: 'foo', marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', tree.children[1], 'foo:bar');
@@ -180,7 +181,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    var transformer = control({name: 'foo'});
+    var transformer = control({name: 'foo', marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', tree.children[1], 'foo:bar');
@@ -205,7 +206,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    var transformer = control({name: 'foo'});
+    var transformer = control({name: 'foo', marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', tree.children[1], 'foo:bar');
@@ -228,7 +229,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    return control({name: 'foo'});
+    return control({name: 'foo', marker: mdastMarker});
   }).process('<!--foo test-->', function (err) {
     t.equal(
       String(err),
@@ -239,7 +240,7 @@ test('control()', function (t) {
   });
 
   remark().use(toc).use(function () {
-    var transformer = control({name: 'foo'});
+    var transformer = control({name: 'foo', marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', {line: 5, column: 1}, 'foo:bar');
@@ -266,7 +267,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    var transformer = control({name: 'foo'});
+    var transformer = control({name: 'foo', marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', {line: 5, column: 1}, 'foo:bar');
@@ -294,7 +295,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    var transformer = control({name: 'foo'});
+    var transformer = control({name: 'foo', marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', 'foo:bar');
@@ -312,7 +313,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    var transformer = control({name: 'foo'});
+    var transformer = control({name: 'foo', marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', tree.position.end, 'foo:bar');
@@ -333,7 +334,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    var transformer = control({name: 'foo'});
+    var transformer = control({name: 'foo', marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', tree.children[1].position.end, 'foo:bar');
@@ -355,7 +356,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    var transformer = control({name: 'foo'});
+    var transformer = control({name: 'foo', marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', tree.children[1], 'foo:bar');
@@ -382,7 +383,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    var transformer = control({name: 'foo'});
+    var transformer = control({name: 'foo', marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', 'foo:bar');
@@ -402,7 +403,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    return control({name: 'foo'});
+    return control({name: 'foo', marker: mdastMarker});
   }).process([
     '<!doctype html>',
     '',
@@ -418,7 +419,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    return control({name: 'foo', known: ['known']});
+    return control({name: 'foo', known: ['known'], marker: mdastMarker});
   }).process([
     '<!--foo ignore known-->',
     '',
@@ -434,7 +435,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    var transformer = control({name: 'foo', source: 'baz'});
+    var transformer = control({name: 'foo', source: 'baz', marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', tree.children[1], 'baz:bar');
@@ -456,7 +457,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    var transformer = control({name: 'alpha', source: ['bravo', 'charlie']});
+    var transformer = control({name: 'alpha', source: ['bravo', 'charlie'], marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', tree.children[1], 'bravo:delta');
@@ -483,7 +484,7 @@ test('control()', function (t) {
   });
 
   remark().use(function () {
-    var transformer = control({name: 'foo', disable: ['bar']});
+    var transformer = control({name: 'foo', disable: ['bar'], marker: mdastMarker});
 
     return function (tree, file) {
       file.message('Error', tree.children[0], 'foo:bar');
@@ -506,7 +507,8 @@ test('control()', function (t) {
     var transformer = control({
       name: 'foo',
       reset: true,
-      enable: ['bar']
+      enable: ['bar'],
+      marker: mdastMarker
     });
 
     return function (tree, file) {

--- a/test.js
+++ b/test.js
@@ -8,525 +8,660 @@ var control = require('./');
 
 test('control()', function (t) {
   t.throws(function () {
-    remark().use(control).freeze();
+    remark()
+      .use(control)
+      .freeze();
   }, /Expected `name` in `options`, got `undefined`/);
 
-  remark().use(function () {
-    var transformer = control({name: 'foo', marker: mdastMarker});
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        marker: mdastMarker,
+        test: 'html'
+      });
 
-    return function (tree, file) {
-      file.message('Error', tree.children[1], 'foo:bar');
-      transformer(tree, file);
-    };
-  }).process([
-    '<!--foo disable bar-->',
-    '',
-    'This is a paragraph.'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
+      return function (tree, file) {
+        file.message('Error', tree.children[1], 'foo:bar');
+        transformer(tree, file);
+      };
+    })
+    .process(
+      ['<!--foo disable bar-->', '', 'This is a paragraph.'].join('\n'),
+      function (err, file) {
+        t.ifError(err, 'should not fail');
 
-    t.deepEqual(
-      file.messages.map(String),
-      [],
-      'should “disable” a message'
+        t.deepEqual(
+          file.messages.map(String),
+          [],
+          'should “disable” a message'
+        );
+      }
     );
-  });
 
-  remark().use(function () {
-    var transformer = control({name: 'foo', marker: mdastMarker});
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        marker: mdastMarker,
+        test: 'html'
+      });
 
-    return function (tree, file) {
-      file.message('Error', tree.children[1], 'foo:bar');
+      return function (tree, file) {
+        file.message('Error', tree.children[1], 'foo:bar');
 
-      transformer(tree, file);
-    };
-  }).process([
-    '<!--foo disable-->',
-    '',
-    'This is a paragraph.'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
+        transformer(tree, file);
+      };
+    })
+    .process(
+      ['<!--foo disable-->', '', 'This is a paragraph.'].join('\n'),
+      function (err, file) {
+        t.ifError(err, 'should not fail');
 
-    t.deepEqual(
-      file.messages.map(String),
-      [],
-      'should “disable” all message without `ruleId`s'
+        t.deepEqual(
+          file.messages.map(String),
+          [],
+          'should “disable” all message without `ruleId`s'
+        );
+      }
     );
-  });
 
-  remark().use(function () {
-    var transformer = control({name: 'foo', reset: true, marker: mdastMarker});
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        reset: true,
+        marker: mdastMarker,
+        test: 'html'
+      });
 
-    return function (tree, file) {
-      file.message('Error', tree.children[0], 'foo:bar');
-      file.message('Error', tree.children[2], 'foo:bar');
+      return function (tree, file) {
+        file.message('Error', tree.children[0], 'foo:bar');
+        file.message('Error', tree.children[2], 'foo:bar');
 
-      transformer(tree, file);
-    };
-  }).process([
-    'This is a paragraph.',
-    '',
-    '<!--foo enable-->',
-    '',
-    'This is a paragraph.'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
+        transformer(tree, file);
+      };
+    })
+    .process(
+      [
+        'This is a paragraph.',
+        '',
+        '<!--foo enable-->',
+        '',
+        'This is a paragraph.'
+      ].join('\n'),
+      function (err, file) {
+        t.ifError(err, 'should not fail');
 
-    t.deepEqual(
-      file.messages.map(String),
-      ['5:1-5:21: Error'],
-      'should support `reset`'
+        t.deepEqual(
+          file.messages.map(String),
+          ['5:1-5:21: Error'],
+          'should support `reset`'
+        );
+      }
     );
-  });
 
-  remark().use(function () {
-    var transformer = control({name: 'foo', reset: true, marker: mdastMarker});
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        reset: true,
+        marker: mdastMarker,
+        test: 'html'
+      });
 
-    return function (tree, file) {
-      file.message('Error', tree.children[1], 'foo:bar');
+      return function (tree, file) {
+        file.message('Error', tree.children[1], 'foo:bar');
 
-      transformer(tree, file);
-    };
-  }).process([
-    '<!--foo enable bar-->',
-    '',
-    'This is a paragraph.'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
+        transformer(tree, file);
+      };
+    })
+    .process(
+      ['<!--foo enable bar-->', '', 'This is a paragraph.'].join('\n'),
+      function (err, file) {
+        t.ifError(err, 'should not fail');
 
-    t.deepEqual(
-      file.messages.map(String),
-      ['3:1-3:21: Error'],
-      'should enable with a marker, when `reset`'
+        t.deepEqual(
+          file.messages.map(String),
+          ['3:1-3:21: Error'],
+          'should enable with a marker, when `reset`'
+        );
+      }
     );
-  });
 
-  remark().use(function () {
-    var transformer = control({name: 'foo', marker: mdastMarker});
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        marker: mdastMarker,
+        test: 'html'
+      });
 
-    return function (tree, file) {
-      file.message('Error', tree.children[1], 'foo:bar');
-      file.message('Error', tree.children[3], 'foo:bar');
+      return function (tree, file) {
+        file.message('Error', tree.children[1], 'foo:bar');
+        file.message('Error', tree.children[3], 'foo:bar');
 
-      transformer(tree, file);
-    };
-  }).process([
-    '<!--foo disable bar-->',
-    '',
-    'This is a paragraph.',
-    '',
-    '<!--foo enable bar-->',
-    '',
-    'This is a paragraph.'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
+        transformer(tree, file);
+      };
+    })
+    .process(
+      [
+        '<!--foo disable bar-->',
+        '',
+        'This is a paragraph.',
+        '',
+        '<!--foo enable bar-->',
+        '',
+        'This is a paragraph.'
+      ].join('\n'),
+      function (err, file) {
+        t.ifError(err, 'should not fail');
 
-    t.deepEqual(
-      file.messages.map(String),
-      ['7:1-7:21: Error'],
-      'should enable a message'
+        t.deepEqual(
+          file.messages.map(String),
+          ['7:1-7:21: Error'],
+          'should enable a message'
+        );
+      }
     );
-  });
 
-  remark().use(function () {
-    var transformer = control({name: 'foo', marker: mdastMarker});
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        marker: mdastMarker,
+        test: 'html'
+      });
 
-    return function (tree, file) {
-      file.message('Error', tree.children[1], 'foo:bar');
-      file.message('Error', tree.children[3], 'foo:bar');
+      return function (tree, file) {
+        file.message('Error', tree.children[1], 'foo:bar');
+        file.message('Error', tree.children[3], 'foo:bar');
 
-      transformer(tree, file);
-    };
-  }).process([
-    '<!--foo disable bar-->',
-    '',
-    'This is a paragraph.',
-    '',
-    '<!--foo enable-->',
-    '',
-    'This is a paragraph.'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
+        transformer(tree, file);
+      };
+    })
+    .process(
+      [
+        '<!--foo disable bar-->',
+        '',
+        'This is a paragraph.',
+        '',
+        '<!--foo enable-->',
+        '',
+        'This is a paragraph.'
+      ].join('\n'),
+      function (err, file) {
+        t.ifError(err, 'should not fail');
 
-    t.deepEqual(
-      file.messages.map(String),
-      ['7:1-7:21: Error'],
-      'should enable all message without `ruleId`s'
+        t.deepEqual(
+          file.messages.map(String),
+          ['7:1-7:21: Error'],
+          'should enable all message without `ruleId`s'
+        );
+      }
     );
-  });
 
-  remark().use(function () {
-    var transformer = control({name: 'foo', marker: mdastMarker});
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        marker: mdastMarker,
+        test: 'html'
+      });
 
-    return function (tree, file) {
-      file.message('Error', tree.children[1], 'foo:bar');
-      file.message('Error', tree.children[2], 'foo:bar');
+      return function (tree, file) {
+        file.message('Error', tree.children[1], 'foo:bar');
+        file.message('Error', tree.children[2], 'foo:bar');
 
-      transformer(tree, file);
-    };
-  }).process([
-    '<!--foo ignore bar-->',
-    '',
-    'This is a paragraph.',
-    '',
-    'This is a paragraph.'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
+        transformer(tree, file);
+      };
+    })
+    .process(
+      [
+        '<!--foo ignore bar-->',
+        '',
+        'This is a paragraph.',
+        '',
+        'This is a paragraph.'
+      ].join('\n'),
+      function (err, file) {
+        t.ifError(err, 'should not fail');
 
-    t.deepEqual(
-      file.messages.map(String),
-      ['5:1-5:21: Error'],
-      'should ignore a message'
+        t.deepEqual(
+          file.messages.map(String),
+          ['5:1-5:21: Error'],
+          'should ignore a message'
+        );
+      }
     );
-  });
 
-  remark().use(function () {
-    var transformer = control({name: 'foo', marker: mdastMarker});
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        marker: mdastMarker,
+        test: 'html'
+      });
 
-    return function (tree, file) {
-      file.message('Error', tree.children[1], 'foo:bar');
-      file.message('Error', tree.children[2], 'foo:bar');
+      return function (tree, file) {
+        file.message('Error', tree.children[1], 'foo:bar');
+        file.message('Error', tree.children[2], 'foo:bar');
 
-      transformer(tree, file);
-    };
-  }).process([
-    '<!--foo ignore-->',
-    '',
-    'This is a paragraph.',
-    '',
-    'This is a paragraph.'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
+        transformer(tree, file);
+      };
+    })
+    .process(
+      [
+        '<!--foo ignore-->',
+        '',
+        'This is a paragraph.',
+        '',
+        'This is a paragraph.'
+      ].join('\n'),
+      function (err, file) {
+        t.ifError(err, 'should not fail');
 
-    t.deepEqual(
-      file.messages.map(String),
-      ['5:1-5:21: Error'],
-      'should ignore all message without `ruleId`s'
+        t.deepEqual(
+          file.messages.map(String),
+          ['5:1-5:21: Error'],
+          'should ignore all message without `ruleId`s'
+        );
+      }
     );
-  });
 
-  remark().use(function () {
-    var transformer = control({name: 'foo', marker: mdastMarker});
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        marker: mdastMarker,
+        test: 'html'
+      });
 
-    return function (tree, file) {
-      file.message('Error', tree.children[1], 'foo:bar');
-      file.message('Error', tree.children[1], 'foo:baz');
+      return function (tree, file) {
+        file.message('Error', tree.children[1], 'foo:bar');
+        file.message('Error', tree.children[1], 'foo:baz');
 
-      transformer(tree, file);
-    };
-  }).process([
-    '<!--foo ignore bar baz-->',
-    '',
-    'This is a paragraph.'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
+        transformer(tree, file);
+      };
+    })
+    .process(
+      ['<!--foo ignore bar baz-->', '', 'This is a paragraph.'].join('\n'),
+      function (err, file) {
+        t.ifError(err, 'should not fail');
 
-    t.deepEqual(
-      file.messages.map(String),
-      [],
-      'should ignore multiple rules'
+        t.deepEqual(
+          file.messages.map(String),
+          [],
+          'should ignore multiple rules'
+        );
+      }
     );
-  });
 
-  remark().use(function () {
-    return control({name: 'foo', marker: mdastMarker});
-  }).process('<!--foo test-->', function (err) {
-    t.equal(
-      String(err),
-      '1:1-1:16: Unknown keyword `test`: ' +
-      'expected `\'enable\'`, `\'disable\'`, or `\'ignore\'`',
-      'should fail on invalid verbs'
-    );
-  });
-
-  remark().use(toc).use(function () {
-    var transformer = control({name: 'foo', marker: mdastMarker});
-
-    return function (tree, file) {
-      file.message('Error', {line: 5, column: 1}, 'foo:bar');
-      file.message('Error', {line: 7, column: 1}, 'foo:bar');
-
-      transformer(tree, file);
-    };
-  }).process([
-    '# README',
-    '',
-    '## Table of Contents',
-    '',
-    '*  [Another Header](#another-header)',
-    '',
-    '## Another header'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
-
-    t.deepEqual(
-      file.messages.map(String),
-      ['7:1: Error'],
-      'should ignore gaps'
-    );
-  });
-
-  remark().use(function () {
-    var transformer = control({name: 'foo', marker: mdastMarker});
-
-    return function (tree, file) {
-      file.message('Error', {line: 5, column: 1}, 'foo:bar');
-      file.message('Error', {line: 5, column: 1}, 'foo:bar');
-
-      /* Remove list. */
-      tree.children.pop();
-
-      transformer(tree, file);
-    };
-  }).process([
-    '# README',
-    '',
-    '## Table of Contents',
-    '',
-    '*  [This is removed](#this-is-removed)'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
-
-    t.deepEqual(
-      file.messages.map(String),
-      [],
-      'should ignore final gaps'
-    );
-  });
-
-  remark().use(function () {
-    var transformer = control({name: 'foo', marker: mdastMarker});
-
-    return function (tree, file) {
-      file.message('Error', 'foo:bar');
-
-      transformer(tree, file);
-    };
-  }).process('', function (err, file) {
-    t.ifError(err, 'should not fail');
-
-    t.deepEqual(
-      file.messages.map(String),
-      ['1:1: Error'],
-      'should support empty documents'
-    );
-  });
-
-  remark().use(function () {
-    var transformer = control({name: 'foo', marker: mdastMarker});
-
-    return function (tree, file) {
-      file.message('Error', tree.position.end, 'foo:bar');
-
-      transformer(tree, file);
-    };
-  }).process([
-    '# README',
-    ''
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
-
-    t.deepEqual(
-      file.messages.map(String),
-      ['2:1: Error'],
-      'should message at the end of the document'
-    );
-  });
-
-  remark().use(function () {
-    var transformer = control({name: 'foo', marker: mdastMarker});
-
-    return function (tree, file) {
-      file.message('Error', tree.children[1].position.end, 'foo:bar');
-
-      transformer(tree, file);
-    };
-  }).process([
-    '# README',
-    '',
-    '*   List'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
-
-    t.deepEqual(
-      file.messages.map(String),
-      ['3:9: Error'],
-      'should message at the end of the document'
-    );
-  });
-
-  remark().use(function () {
-    var transformer = control({name: 'foo', marker: mdastMarker});
-
-    return function (tree, file) {
-      file.message('Error', tree.children[1], 'foo:bar');
-      file.message('Error', tree.children[3], 'foo:bar');
-
-      transformer(tree, file);
-    };
-  }).process([
-    '<!--foo disable bar-->',
-    '',
-    'This is a paragraph.',
-    '',
-    '<!--foo disable bar-->',
-    '',
-    'This is a paragraph.'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
-
-    t.deepEqual(
-      file.messages.map(String),
-      [],
-      'should ignore double disables'
-    );
-  });
-
-  remark().use(function () {
-    var transformer = control({name: 'foo', marker: mdastMarker});
-
-    return function (tree, file) {
-      file.message('Error', 'foo:bar');
-
-      transformer(tree, file);
-    };
-  }).process([
-    'Foo'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
-
-    t.deepEqual(
-      file.messages.map(String),
-      ['1:1: Error'],
-      'should not ignore messages without location information'
-    );
-  });
-
-  remark().use(function () {
-    return control({name: 'foo', marker: mdastMarker});
-  }).process([
-    '<!doctype html>',
-    '',
-    '<!--bar baz qux-->'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
-
-    t.deepEqual(
-      file.messages.map(String),
-      [],
-      'should ignore non-markers'
-    );
-  });
-
-  remark().use(function () {
-    return control({name: 'foo', known: ['known'], marker: mdastMarker});
-  }).process([
-    '<!--foo ignore known-->',
-    '',
-    '<!--foo ignore unknown-->'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
-
-    t.deepEqual(
-      file.messages.map(String),
-      ['3:1-3:26: Unknown rule: cannot ignore `\'unknown\'`'],
-      'should support a list of `known` values, and warn on unknowns'
-    );
-  });
-
-  remark().use(function () {
-    var transformer = control({name: 'foo', source: 'baz', marker: mdastMarker});
-
-    return function (tree, file) {
-      file.message('Error', tree.children[1], 'baz:bar');
-
-      transformer(tree, file);
-    };
-  }).process([
-    '<!--foo ignore bar-->',
-    '',
-    'Foo'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
-
-    t.deepEqual(
-      file.messages.map(String),
-      [],
-      'should ignore by `source`, when given as a string'
-    );
-  });
-
-  remark().use(function () {
-    var transformer = control({name: 'alpha', source: ['bravo', 'charlie'], marker: mdastMarker});
-
-    return function (tree, file) {
-      file.message('Error', tree.children[1], 'bravo:delta');
-      file.message('Error', tree.children[3], 'charlie:echo');
-
-      transformer(tree, file);
-    };
-  }).process([
-    '<!--alpha ignore delta-->',
-    '',
-    'Foxtrot',
-    '',
-    '<!--alpha ignore echo-->',
-    '',
-    'Golf'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
-
-    t.deepEqual(
-      file.messages.map(String),
-      [],
-      'should ignore by `source`, when given as an array'
-    );
-  });
-
-  remark().use(function () {
-    var transformer = control({name: 'foo', disable: ['bar'], marker: mdastMarker});
-
-    return function (tree, file) {
-      file.message('Error', tree.children[0], 'foo:bar');
-
-      transformer(tree, file);
-    };
-  }).process([
-    'This is a paragraph.'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
-
-    t.deepEqual(
-      file.messages.map(String),
-      [],
-      'should support initial `disable`s'
-    );
-  });
-
-  remark().use(function () {
-    var transformer = control({
-      name: 'foo',
-      reset: true,
-      enable: ['bar'],
-      marker: mdastMarker
+  remark()
+    .use(function () {
+      return control({name: 'foo', marker: mdastMarker, test: 'html'});
+    })
+    .process('<!--foo test-->', function (err) {
+      t.equal(
+        String(err),
+        '1:1-1:16: Unknown keyword `test`: ' +
+          'expected `\'enable\'`, `\'disable\'`, or `\'ignore\'`',
+        'should fail on invalid verbs'
+      );
     });
 
-    return function (tree, file) {
-      file.message('Error', tree.children[0], 'foo:bar');
+  remark()
+    .use(toc)
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        marker: mdastMarker,
+        test: 'html'
+      });
 
-      transformer(tree, file);
-    };
-  }).process([
-    'This is a paragraph.'
-  ].join('\n'), function (err, file) {
-    t.ifError(err, 'should not fail');
+      return function (tree, file) {
+        file.message('Error', {line: 5, column: 1}, 'foo:bar');
+        file.message('Error', {line: 7, column: 1}, 'foo:bar');
 
-    t.deepEqual(
-      file.messages.map(String),
-      ['1:1-1:21: Error'],
-      'should support initial `enable`s'
+        transformer(tree, file);
+      };
+    })
+    .process(
+      [
+        '# README',
+        '',
+        '## Table of Contents',
+        '',
+        '*  [Another Header](#another-header)',
+        '',
+        '## Another header'
+      ].join('\n'),
+      function (err, file) {
+        t.ifError(err, 'should not fail');
+
+        t.deepEqual(
+          file.messages.map(String),
+          ['7:1: Error'],
+          'should ignore gaps'
+        );
+      }
     );
-  });
+
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        marker: mdastMarker,
+        test: 'html'
+      });
+
+      return function (tree, file) {
+        file.message('Error', {line: 5, column: 1}, 'foo:bar');
+        file.message('Error', {line: 5, column: 1}, 'foo:bar');
+
+        /* Remove list. */
+        tree.children.pop();
+
+        transformer(tree, file);
+      };
+    })
+    .process(
+      [
+        '# README',
+        '',
+        '## Table of Contents',
+        '',
+        '*  [This is removed](#this-is-removed)'
+      ].join('\n'),
+      function (err, file) {
+        t.ifError(err, 'should not fail');
+
+        t.deepEqual(file.messages.map(String), [], 'should ignore final gaps');
+      }
+    );
+
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        marker: mdastMarker,
+        test: 'html'
+      });
+
+      return function (tree, file) {
+        file.message('Error', 'foo:bar');
+
+        transformer(tree, file);
+      };
+    })
+    .process('', function (err, file) {
+      t.ifError(err, 'should not fail');
+
+      t.deepEqual(
+        file.messages.map(String),
+        ['1:1: Error'],
+        'should support empty documents'
+      );
+    });
+
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        marker: mdastMarker,
+        test: 'html'
+      });
+
+      return function (tree, file) {
+        file.message('Error', tree.position.end, 'foo:bar');
+
+        transformer(tree, file);
+      };
+    })
+    .process(['# README', ''].join('\n'), function (err, file) {
+      t.ifError(err, 'should not fail');
+
+      t.deepEqual(
+        file.messages.map(String),
+        ['2:1: Error'],
+        'should message at the end of the document'
+      );
+    });
+
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        marker: mdastMarker,
+        test: 'html'
+      });
+
+      return function (tree, file) {
+        file.message('Error', tree.children[1].position.end, 'foo:bar');
+
+        transformer(tree, file);
+      };
+    })
+    .process(['# README', '', '*   List'].join('\n'), function (err, file) {
+      t.ifError(err, 'should not fail');
+
+      t.deepEqual(
+        file.messages.map(String),
+        ['3:9: Error'],
+        'should message at the end of the document'
+      );
+    });
+
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        marker: mdastMarker,
+        test: 'html'
+      });
+
+      return function (tree, file) {
+        file.message('Error', tree.children[1], 'foo:bar');
+        file.message('Error', tree.children[3], 'foo:bar');
+
+        transformer(tree, file);
+      };
+    })
+    .process(
+      [
+        '<!--foo disable bar-->',
+        '',
+        'This is a paragraph.',
+        '',
+        '<!--foo disable bar-->',
+        '',
+        'This is a paragraph.'
+      ].join('\n'),
+      function (err, file) {
+        t.ifError(err, 'should not fail');
+
+        t.deepEqual(
+          file.messages.map(String),
+          [],
+          'should ignore double disables'
+        );
+      }
+    );
+
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        marker: mdastMarker,
+        test: 'html'
+      });
+
+      return function (tree, file) {
+        file.message('Error', 'foo:bar');
+
+        transformer(tree, file);
+      };
+    })
+    .process(['Foo'].join('\n'), function (err, file) {
+      t.ifError(err, 'should not fail');
+
+      t.deepEqual(
+        file.messages.map(String),
+        ['1:1: Error'],
+        'should not ignore messages without location information'
+      );
+    });
+
+  remark()
+    .use(function () {
+      return control({name: 'foo', marker: mdastMarker, test: 'html'});
+    })
+    .process(['<!doctype html>', '', '<!--bar baz qux-->'].join('\n'), function (
+      err,
+      file
+    ) {
+      t.ifError(err, 'should not fail');
+
+      t.deepEqual(file.messages.map(String), [], 'should ignore non-markers');
+    });
+
+  remark()
+    .use(function () {
+      return control({
+        name: 'foo',
+        known: ['known'],
+        marker: mdastMarker,
+        test: 'html'
+      });
+    })
+    .process(
+      ['<!--foo ignore known-->', '', '<!--foo ignore unknown-->'].join('\n'),
+      function (err, file) {
+        t.ifError(err, 'should not fail');
+
+        t.deepEqual(
+          file.messages.map(String),
+          ['3:1-3:26: Unknown rule: cannot ignore `\'unknown\'`'],
+          'should support a list of `known` values, and warn on unknowns'
+        );
+      }
+    );
+
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        source: 'baz',
+        marker: mdastMarker,
+        test: 'html'
+      });
+
+      return function (tree, file) {
+        file.message('Error', tree.children[1], 'baz:bar');
+
+        transformer(tree, file);
+      };
+    })
+    .process(['<!--foo ignore bar-->', '', 'Foo'].join('\n'), function (
+      err,
+      file
+    ) {
+      t.ifError(err, 'should not fail');
+
+      t.deepEqual(
+        file.messages.map(String),
+        [],
+        'should ignore by `source`, when given as a string'
+      );
+    });
+
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'alpha',
+        source: ['bravo', 'charlie'],
+        marker: mdastMarker,
+        test: 'html'
+      });
+
+      return function (tree, file) {
+        file.message('Error', tree.children[1], 'bravo:delta');
+        file.message('Error', tree.children[3], 'charlie:echo');
+
+        transformer(tree, file);
+      };
+    })
+    .process(
+      [
+        '<!--alpha ignore delta-->',
+        '',
+        'Foxtrot',
+        '',
+        '<!--alpha ignore echo-->',
+        '',
+        'Golf'
+      ].join('\n'),
+      function (err, file) {
+        t.ifError(err, 'should not fail');
+
+        t.deepEqual(
+          file.messages.map(String),
+          [],
+          'should ignore by `source`, when given as an array'
+        );
+      }
+    );
+
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        disable: ['bar'],
+        marker: mdastMarker,
+        test: 'html'
+      });
+
+      return function (tree, file) {
+        file.message('Error', tree.children[0], 'foo:bar');
+
+        transformer(tree, file);
+      };
+    })
+    .process(['This is a paragraph.'].join('\n'), function (err, file) {
+      t.ifError(err, 'should not fail');
+
+      t.deepEqual(
+        file.messages.map(String),
+        [],
+        'should support initial `disable`s'
+      );
+    });
+
+  remark()
+    .use(function () {
+      var transformer = control({
+        name: 'foo',
+        reset: true,
+        enable: ['bar'],
+        marker: mdastMarker,
+        test: 'html'
+      });
+
+      return function (tree, file) {
+        file.message('Error', tree.children[0], 'foo:bar');
+
+        transformer(tree, file);
+      };
+    })
+    .process(['This is a paragraph.'].join('\n'), function (err, file) {
+      t.ifError(err, 'should not fail');
+
+      t.deepEqual(
+        file.messages.map(String),
+        ['1:1-1:21: Error'],
+        'should support initial `enable`s'
+      );
+    });
 
   t.end();
 });


### PR DESCRIPTION
adds `marker` and `test` as options to allow different ASTs to be used with message control.