### PR TITLE
Remove 'trim' dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,8 +303,5 @@ function detectGaps(tree, file) {
 }
 
 function trim(str) {
-  if (String.prototype.trim) {
-    return str.trim()
-  }
   return str.replace(/^\s*|\s*$/g, '')
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-var trim = require('trim')
 var location = require('vfile-location')
 var visit = require('unist-util-visit')
 
@@ -262,7 +261,7 @@ function detectGaps(tree, file) {
     lastNode.position &&
     lastNode.position.end &&
     offset === lastNode.position.end.offset &&
-    trim(file.toString().slice(offset)) !== ''
+    file.toString().slice(offset).trim() !== ''
   ) {
     update()
 

--- a/index.js
+++ b/index.js
@@ -261,7 +261,7 @@ function detectGaps(tree, file) {
     lastNode.position &&
     lastNode.position.end &&
     offset === lastNode.position.end.offset &&
-    file.toString().slice(offset).trim() !== ''
+    trim(file.toString().slice(offset)) !== ''
   ) {
     update()
 
@@ -300,4 +300,11 @@ function detectGaps(tree, file) {
 
     offset = latest
   }
+}
+
+function trim(str) {
+  if (String.prototype.trim) {
+    return str.trim()
+  }
+  return str.replace(/^\s*|\s*$/g, '')
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "index.js"
   ],
   "dependencies": {
-    "trim": "0.0.1",
     "unist-util-visit": "^1.0.0",
     "vfile-location": "^2.0.0"
   },


### PR DESCRIPTION
The 'trim' dependency is problematic as it doesn't link to its source code from the package.json and while it mentions in README it is licensed under MIT, it doesn't have a full license text in the npm package distribution. The MIT license explicitly specifies:

> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

Thus not attaching the full license text is a discrepancy with the license itself. That said, the main reason to remove the dependency is that it should not be necessary anymore. The ES5 includes
String.prototype.trim() method and [according to MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim) it is fairly well supported even in browsers.

If this gets merged, a new version of `unified-message-control` should be released to mitigate the potential licensing issue.